### PR TITLE
Update PyEmVue to 0.10.1, allows wall plug readings

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 influxdb >= 5.2.3
-pyemvue == 0.9.5
+pyemvue == 0.10.1


### PR DESCRIPTION
Without the version bump Emporia Vue's wall plugs cause the program to error out. this works however on 0.10.1. Example config for clean names:

```
		"devices": [{
				"name": "Home",
				"channels": [
					"AC_Downstairs",
					"AC_Upstairs",
					"Office",
					"Master",
					"Kat's Room",
					"Ella's Room",
					"Washer",
					"Fishtank"
				]
			},
			{
				"name": "Server Rack"
			},
			{
				"name": "Air Filter"
			}
		]
```

"Server Rack" and "Air Filter" being the new wall plugs. 