### PR TITLE
Enable support for skipping Influxdb database creation

### DIFF
--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -195,7 +195,12 @@ try:
         else:
             influx = influxdb.InfluxDBClient(host=config['influxDb']['host'], port=config['influxDb']['port'], database=config['influxDb']['database'], ssl=sslEnable, verify_ssl=sslVerify)
 
-        influx.create_database(config['influxDb']['database'])
+        skipCreateDb = False
+        if 'skip_create_db' in config['influxDb']:
+            skipCreateDb = config['influxDb']['skip_create_db']
+
+        if !skipCreateDb:
+            influx.create_database(config['influxDb']['database'])
 
         if config['influxDb']['reset']:
             info('Resetting database')


### PR DESCRIPTION
I ran into an issue today and figured it'd be relatively simple to fix:

```
2022-01-14 01:51:11.798264 | ERROR | Fatal error: (<class 'influxdb.exceptions.InfluxDBClientError'>, InfluxDBClientError('403: {"error":"error authorizing query: telegraf-solarpi not authorized to execute statement \'CREATE DATABASE metrics\', requires admin privilege"}'), <traceback object at 0x7f0eecdb94c0>)
Traceback (most recent call last):
  File "/opt/vuegraf/vuegraf.py", line 198, in <module>
    influx.create_database(config['influxDb']['database'])
  File "/usr/local/lib/python3.10/site-packages/influxdb/client.py", line 746, in create_database
    self.query("CREATE DATABASE {0}".format(quote_ident(dbname)),
  File "/usr/local/lib/python3.10/site-packages/influxdb/client.py", line 521, in query
    response = self.request(
  File "/usr/local/lib/python3.10/site-packages/influxdb/client.py", line 378, in request
    raise InfluxDBClientError(err_msg, response.status_code)
influxdb.exceptions.InfluxDBClientError: 403: {"error":"error authorizing query: telegraf-solarpi not authorized to execute statement 'CREATE DATABASE metrics', requires admin privilege"}
```

Presently the code tries to run `CREATE DATABASE <db>` on every run.  For setups like mine, where the database already exists and I don't want to give the user admin access, it's helpful to be able to skip that step.

This PR adds logic to look for an additional field (`skip_create_db`) in the config file and skip the create_database call if it's present and set to True.