### PR TITLE
Ingesting Historical Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ InfluxDB v1:
         "user": "root",
         "pass": "root",
         "database": "vue",
-        "reset": false
+        "reset": false,
+        "historyDays": 7
     },
     "accounts": [
         {
@@ -74,7 +75,8 @@ InfluxDB v2:
         "org": "vuegraf",
         "bucket": "vuegraf",
         "token": "veugraf-secret-token",
-        "reset": false
+        "reset": false,
+        "historyDays": 7
     },
     "accounts": [
         {
@@ -85,6 +87,9 @@ InfluxDB v2:
     ]
 }
 ```
+
+# Ingesting Historical Data
+One-minute data from the past `historyDays` days will be ingested into InfluxDB the first time that Vuegraf is run. Emporia currently retains this data for 7 days, and therefore `historyDays` must be less than or equal to `7`. If `historyDays` is set to `0`, no historical data will be ingested into InfluxDB.
 
 ## Advanced Configuration
 To provide more user-friendly names of each Vue device and branch circuit, the following device configuration can be added to the configuration file, within the account block. List each device and circuit in the order that you added them to the Vue mobile app. The channel names do not need to match the names specified in the Vue mobile app but the device names must match. The below example shows two 8-channel Vue devices for a home with two breaker panels.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ InfluxDB v2:
 }
 ```
 
-# Ingesting Historical Data
+## Ingesting Historical Data
 One-minute data from the past `historyDays` days will be ingested into InfluxDB the first time that Vuegraf is run. Emporia currently retains this data for 7 days, and therefore `historyDays` must be less than or equal to `7`. If `historyDays` is set to `0`, no historical data will be ingested into InfluxDB.
 
 ## Advanced Configuration

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -254,12 +254,13 @@ try:
                         extractDataPoints(device, usageDataPoints)
 
                     if history:
-                        info('Loading historical data from past {} days'.format(historyDays))
                         for day in range(historyDays):
+                            info('Loading historical data: {} day ago'.format(day+1))
                             startTime = stopTime - datetime.timedelta(seconds=3600*24*(day+1))
                             endTime = stopTime - datetime.timedelta(seconds=3600*24*day)
                             for gid, device in usages.items():
                                 extractDataPoints(device, usageDataPoints, startTime, endTime)
+                            pauseEvent.wait(30)
                         history = False
 
                     info('Submitting datapoints to database; account="{}"; points={}'.format(account['name'], len(usageDataPoints)))

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -256,10 +256,10 @@ try:
                     if history:
                         for day in range(historyDays):
                             info('Loading historical data: {} day ago'.format(day+1))
-                            histroyStartTime = stopTime - datetime.timedelta(seconds=3600*24*(day+1))
+                            historyStartTime = stopTime - datetime.timedelta(seconds=3600*24*(day+1))
                             historyEndTime = stopTime - datetime.timedelta(seconds=3600*24*day)
                             for gid, device in usages.items():
-                                extractDataPoints(device, usageDataPoints, histroyStartTime, historyEndTime)
+                                extractDataPoints(device, usageDataPoints, historyStartTime, historyEndTime)
                             if not running:
                                 break
                             pauseEvent.wait(30)

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -260,8 +260,13 @@ try:
                             endTime = stopTime - datetime.timedelta(seconds=3600*24*day)
                             for gid, device in usages.items():
                                 extractDataPoints(device, usageDataPoints, startTime, endTime)
+                            if not running:
+                                break
                             pauseEvent.wait(30)
                         history = False
+
+                    if not running:
+                        break
 
                     info('Submitting datapoints to database; account="{}"; points={}'.format(account['name'], len(usageDataPoints)))
                     if influxVersion == 2:

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -136,22 +136,24 @@ def extractDataPoints(device, usageDataPoints, startTime=None, stopTime=None):
             usage, usage_start_time = account['vue'].get_chart_usage(chan, detailedStartTime, stopTime, scale=Scale.SECOND.value, unit=Unit.KWH.value)
             index = 0
             for kwhUsage in usage:
-                if kwhUsage is not None:
-                    timestamp = detailedStartTime + datetime.timedelta(seconds=index)
-                    watts = float(secondsInAMinute * minutesInAnHour * wattsInAKw) * kwhUsage
-                    usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, True))
-                    index += 1
+                if kwhUsage is None:
+                    continue
+                timestamp = detailedStartTime + datetime.timedelta(seconds=index)
+                watts = float(secondsInAMinute * minutesInAnHour * wattsInAKw) * kwhUsage
+                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, True))
+                index += 1
         
         # fetches historical minute data
         if startTime is not None and endTime is not None:
             usage, usage_start_time = account['vue'].get_chart_usage(chan, startTime, stopTime, scale=Scale.MINUTE.value, unit=Unit.KWH.value)
             index = 0
             for kwhUsage in usage:
-                if kwhUsage is not None:
-                    timestamp = startTime + datetime.timedelta(minutes=index)
-                    watts = float(minutesInAnHour * wattsInAKw) * kwhUsage
-                    usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, False))
-                    index += 1
+                if kwhUsage is None:
+                    continue
+                timestamp = startTime + datetime.timedelta(minutes=index)
+                watts = float(minutesInAnHour * wattsInAKw) * kwhUsage
+                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, False))
+                index += 1
 
 startupTime = datetime.datetime.utcnow()
 try:


### PR DESCRIPTION
This PR adds support for ingesting historical one-minute data into InfluxDB the first time that Vuegraf is run. A new parameter is added to the configuration, `historyDays`, to support this feature. Emporia currently retains one-minute data for 7 days, and therefore `historyDays` must be less than or equal to `7`. If `historyDays` is set to `0`, no historical data will be ingested into InfluxDB.

If this PR is accepted, I would be happy to create another PR for ingestion of historical one-hour data. Emporia currently retains one-hour data for the lifetime of the device.