### PR TITLE
Correctly recurse extractDataPoints() for nested devices.

### DIFF
--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -130,7 +130,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
     for chanNum, chan in device.channels.items():
         if chan.nested_devices:
             for gid, nestedDevice in chan.nested_devices.items():
-                extractDataPoints(nestedDevice, usageDataPoints, historyStartTime, historyEndTime)
+                extractDataPoints(nestedDevice, usageDataPoints, pointType, historyStartTime, historyEndTime)
 
         chanName = lookupChannelName(account, chan)
 


### PR DESCRIPTION
I am using vuegraf with nested panels and noticed very weird live data collection from the secondary panel. Looks like a simple bug caused by Python's dynamic typing