### PR TITLE
Introduce timezone, detailedDataSecondsEnabled and detailedDataHoursEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - TBD
 
 ## New features
-- TBD
+- Added `detailedDataSecondsEnabled` and `detailedDataHoursEnabled` to selectively fetch one or (or both) seconds- and hours- resolution data iff `detailedDataEnabled` = `true`
+- Added `timezone` config to allow configuring the timezone according to which end-of-day is calculated.
 
 ## Other changes
 - TBD

--- a/README.md
+++ b/README.md
@@ -91,9 +91,22 @@ The minimum configuration required to start Vuegraf is shown below.
 
 ## Advanced Configuration
 
+### Timezones
+All data is stored in InfluxDB in UTC. To represent day-summary datapoints, vuegraf fetches a day's data at the end of the day in a certain timezone, configured by the configuration field `timezone`.
+- if `timezone` is missing or null or its `upper()` is `"TZ"`, then the "default timezone" will be used
+  - the "default timezone" depends on the deployment method of the script
+    - If you are using Docker, the container has the timezone set to UTC unless the environment `TZ` is set.
+    - If you are running the script natively, it depends on your operating system. For example, in Ubuntu the timezone name is the contents of `/etc/timezone`
+- for all values of `timezone` other than the ones named above, the string **SHOULD** be a valid timezone name.
+
+The configured timezone is only relevant for collecting day-scoped data: the script fetches Emporia's "day to date" counter values, so if the account's timezone does not match the script one's, the last hours of the day will not be counted. For example, if your account is in the `America/Los_Angeles` timezone while the script runs its default UTC configuration in a Docker container, the daily summaries will miss the last 8 hours of every day.
+
+For a list of timezones as of late 2023, consult the `TZ identifier` column of the table at [this wikipedia page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+
 ### Ingesting Historical Data
 
-If desired, it is possible to have Vuegraf import historical data. To do so, run vuegraf.py with the optional `--historydays` parameter with a value between 1 and 720.  When this parameter is provided Vuegraf will start and collect all hourly data points up to the specified parameter, or max history available.  It will also collect one day's summary data for each day, storing it with the timestamp 23:59:59 for each day.  It collects the time using your local server time, but stores it in influxDB in UTC.
+If desired, it is possible to have Vuegraf import historical data. To do so, run vuegraf.py with the optional `--historydays` parameter with a value between 1 and 720.  When this parameter is provided Vuegraf will start and collect all hourly data points up to the specified parameter, or max history available.  It will also collect one day's summary data for each day, storing it with the timestamp 23:59:59 for each day.  It collects the time using the configured timezone, but stores it in influxDB in UTC.
 
 IMPORTANT - If you restart Vuegraf with `--historydays` on the command line (or forget to remove it from the dockerfile) it will import history data _again_. This will likely cause confusion with your data since you will now have duplicate/overlapping data. For best results, only enable `--historydays` on a single run.
 
@@ -226,13 +239,17 @@ body = {text: "🔴 ${r._notification_rule_name} -> ${r._check_name}"}
 
 # Additional Topics
 
-## Per-second Data Details
+## Per-second and per-hour Data Details
 
-By default, Vuegraf will poll every minute to collect the energy usage value over the past 60 seconds. This results in a single value being capture per minute per channel, or 60 values per hour per channel. If you also would like to see per-second values, you can enable the detailed collection, which is polled once per hour, and backfilled over the previous 3600 seconds. This API call is very expensive on the Emporia servers, so it should not be polled more frequently than once per hour. To enable this detailed data, add (or update) the top-level `detailedDataEnabled` configuration value with a value of `true`.  The details is also what pulls the Hourly datapoint.  
+By default, Vuegraf will poll every minute to collect the energy usage value over the past 60 seconds. This results in a single value being captured per minute per channel, or 60 values per hour per channel. If you also would like to also fetch per-second and/or per-hour values, you can enable the detailed collection, which is polled once per hour, and backfilled over the previous 3600 seconds. This API call is very expensive on the Emporia servers, so it should not be polled more frequently than once per hour. To enable this detailed data, add (or update) the top-level `detailedDataEnabled` configuration value with a value of `true`.
 
 ```
 detailedDataEnabled: true
 ```
+
+If `detailedDataEnabled` is set to `true`, the following two configuration fields become relevant. Notice that they are _not_ mutuall exclusive and are actually both set to `true` unless overridden:
+- `detailedDataSecondsEnabled` (default value is `true`): fetch and store per-second data every hour
+- `detailedDataSecondsEnabled` (default value is `true`): fetch and store per-hour data every hour
 
 For every datapoint a tag is stored in InfluxDB for the type of measurement
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ detailedDataEnabled: true
 
 If `detailedDataEnabled` is set to `true`, the following two configuration fields become relevant. Notice that they are _not_ mutuall exclusive and are actually both set to `true` unless overridden:
 - `detailedDataSecondsEnabled` (default value is `true`): fetch and store per-second data every hour
-- `detailedDataSecondsEnabled` (default value is `true`): fetch and store per-hour data every hour
+- `detailedDataHoursEnabled` (default value is `true`): fetch and store per-hour data every hour
 
 For every datapoint a tag is stored in InfluxDB for the type of measurement
 

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -302,6 +302,10 @@ try:
     detailedSecondsEnabled = detailedDataEnabled and getConfigValue('detailedDataSecondsEnabled', True)
     detailedHoursEnabled = detailedDataEnabled and getConfigValue('detailedDataHoursEnabled', True)
     info('Settings -> updateIntervalSecs: {}, detailedEnabled: {}, detailedIntervalSecs: {}'.format(intervalSecs, detailedDataEnabled, detailedIntervalSecs))
+    if detailedDataEnabled and not (detailedSecondsEnabled or detailedHoursEnabled):
+        error('detailedDataEnabled is set but none of [detailedSecondsEnabled, detailedHoursEnabled] is set. No detailed data will be collected')
+        detailedDataEnabled = False
+        
     lagSecs = getConfigValue('lagSecs', 5)
     accountTimeZoneName = getConfigValue('timezone', None)
     accountTimeZone = pytz.timezone(accountTimeZoneName) if accountTimeZoneName is not None and accountTimeZoneName.upper() != "TZ" else None

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -302,9 +302,6 @@ try:
     detailedSecondsEnabled = detailedDataEnabled and getConfigValue('detailedDataSecondsEnabled', True)
     detailedHoursEnabled = detailedDataEnabled and getConfigValue('detailedDataHoursEnabled', True)
     info('Settings -> updateIntervalSecs: {}, detailedEnabled: {}, detailedIntervalSecs: {}'.format(intervalSecs, detailedDataEnabled, detailedIntervalSecs))
-    if detailedDataEnabled and not (detailedSecondsEnabled or detailedHoursEnabled):
-        error('detailedDataEnabled is set but none of [detailedSecondsEnabled, detailedHoursEnabled] is set. No detailed data will be collected')
-        detailedDataEnabled = False
         
     lagSecs = getConfigValue('lagSecs', 5)
     accountTimeZoneName = getConfigValue('timezone', None)

--- a/vuegraf.json.sample
+++ b/vuegraf.json.sample
@@ -8,6 +8,9 @@
     },
     "updateIntervalSecs": 60,
     "detailedDataEnabled": true,
+    "detailedDataSecondsEnabled": true,
+    "detailedDataHoursEnabled": true,
+    "timezone": "TZ",
     "accounts": [
         {
             "name": "Primary Residence",
@@ -37,7 +40,7 @@
                         "Landscape Features",
                         "Septic Pump",
                         "Deep Freeze",
-                        "Sprinkler Pump"        
+                        "Sprinkler Pump"
                     ]
                 }
             ]


### PR DESCRIPTION
This MR:

## introduces `detailedDataSecondsEnabled` and `detailedDataHoursEnabled`
These are configuration options to selectively disable either hourly or per-second data collection. The reasoning is that collecting per-second data is expensive for both Emporia servers and the user (storage-wise and CPU-wise for underpowered shared servers). I run the script on an underpowered Intel Atom J4125 and the once-hourly fetch of 3600 datapoints per channel is a 10second x 50% CPU for data I don't need.

## introduces `timezone`
This is a configuration knob to configure the timezone for the calculation of "end of day". Although it is strictly speaking not necessary, as the same end effect can be achieved via configuring the host system and/or Docker container, the preexisting way of doing things has certain disadvantages:
 - for the Docker container, it is highly unlikely for the average user to be in UTC timezone. Therefore everyone gets silently incorrect (truncated) counters for the daily counters and discovering the erroneous data and its root cause is a frustrating process
 - for the native deployment, the server timezone will _usually_ be the correct timezone, but for cases where it isn't one needs to override the "server timezone" for one process in the system.

IMO it's just cleaner to make the account timezone a native functionality of the script.

## updates the documentation
Easy-peasy update to README and json.sample files to reflect the above.

## Add some whitespace around `=` in preexisting code to make it consistent with surroundings.