### PR TITLE
Fix collection of daily statistics past end-of-month

### DIFF
--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -348,7 +348,7 @@ try:
                         for gid, device in usages.items():
                             extractDataPoints(device, usageDataPoints, 'Hour', historyStartTime)
 
-                if pastDay.day < curDay.day:
+                if pastDay.day != curDay.day:
                     usages = account['vue'].get_device_list_usage(deviceGids, pastDay, scale=Scale.DAY.value, unit=Unit.KWH.value)
                     historyStartTime = pastDay.astimezone(pytz.UTC)
                     verbose('Collecting previous day: {}Local - {}UTC,  '.format(pastDay, historyStartTime))


### PR DESCRIPTION
vuegraf stops collecting daily statistics when a new month starts, because of `pastDay.day < curDay.day` (e.g. `[28..31]) < 1` which is never true). A technically correct solution would be `(pastDay.year, pastDay.month, pastDay.day) < (curDay.year, curDay.month, curDay.day)` but assuming we don't have gaps longer than a month in a given process' lifetime, the simpler solution works as well.