### PR TITLE
Issue #177: Fix the dumpPoints function when running on influxdb v1

### DIFF
--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -18,6 +18,7 @@ import traceback
 from threading import Event
 import argparse
 import pytz
+import pprint
 
 # InfluxDB v1
 import influxdb
@@ -133,7 +134,10 @@ def dumpPoints(label, usageDataPoints):
     if args.debug:
         debug(label)
         for point in usageDataPoints:
-            debug('  {}'.format(point.to_line_protocol()))
+            if influxVersion == 2:
+                debug('  {}'.format(point.to_line_protocol()))
+            else:
+                debug(f'  {pprint.pformat(point)}')
 
 def getLastDBTimeStamp(chanName, pointType, fooStartTime, fooStopTime, fooHistoryFlag):
     timeStr = ''

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -350,12 +350,6 @@ try:
         action='store_true',
         default=False,
         help='Drop database and create a new one. USE WITH CAUTION - WILL RESULT IN COMPLETE VUEGRAF DATA LOSS!')
-    parser.add_argument(
-        '--dryrun',
-        help='Read from the API and process the data, but do not write to influxdb',
-        action='store_true',
-        default=False
-        )
     args = parser.parse_args()
     info('Starting Vuegraf version {}'.format(__version__))
 
@@ -516,13 +510,10 @@ try:
                         # Write to database after each historical batch to prevent timeout issues on large history intervals.
                         info('Submitting datapoints to database; account="{}"; points={}'.format(account['name'], len(usageDataPoints)))
                         dumpPoints("Sending to database", usageDataPoints)
-                        if args.dryrun:
-                            info('Dryrun mode enabled.  Skipping database write.')
+                        if influxVersion == 2:
+                            write_api.write(bucket=bucket, record=usageDataPoints)
                         else:
-                            if influxVersion == 2:
-                                write_api.write(bucket=bucket, record=usageDataPoints)
-                            else:
-                                influx.write_points(usageDataPoints,batch_size=5000)
+                            influx.write_points(usageDataPoints,batch_size=5000)
                         usageDataPoints = []
                         pauseEvent.wait(5)
                     history = False
@@ -533,13 +524,10 @@ try:
                 if not historyrun:
                     info('Submitting datapoints to database; account="{}"; points={}'.format(account['name'], len(usageDataPoints)))
                     dumpPoints("Sending to database", usageDataPoints)
-                    if args.dryrun:
-                        info('Dryrun mode enabled.  Skipping database write.')
+                    if influxVersion == 2:
+                        write_api.write(bucket=bucket, record=usageDataPoints)
                     else:
-                        if influxVersion == 2:
-                            write_api.write(bucket=bucket, record=usageDataPoints)
-                        else:
-                            influx.write_points(usageDataPoints,batch_size=5000)
+                        influx.write_points(usageDataPoints,batch_size=5000)
 
                 # Resuming logging of normal datapoints after history collection has completed.
                 if not history and historyrun:


### PR DESCRIPTION
This function uses the to_line_protocol() method which only exists on the influxdb_client.Point object (the v2 API), resulting in:

AttributeError: 'dict' object has no attribute 'to_line_protocol'

Updated dumpPoints to also support dumping points created for influxdb v1

This PR addresses issue #177