### PR TITLE
Issue #179: Add in a 'station_name' tag for every datapoint

### DIFF
--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -354,12 +354,6 @@ try:
         action='store_true',
         default=False,
         help='Drop database and create a new one. USE WITH CAUTION - WILL RESULT IN COMPLETE VUEGRAF DATA LOSS!')
-    parser.add_argument(
-        '--dryrun',
-        help='Read from the API and process the data, but do not write to influxdb',
-        action='store_true',
-        default=False
-        )
     args = parser.parse_args()
     info('Starting Vuegraf version {}'.format(__version__))
 
@@ -520,13 +514,10 @@ try:
                         # Write to database after each historical batch to prevent timeout issues on large history intervals.
                         info('Submitting datapoints to database; account="{}"; points={}'.format(account['name'], len(usageDataPoints)))
                         dumpPoints("Sending to database", usageDataPoints)
-                        if args.dryrun:
-                            info('Dryrun mode enabled.  Skipping database write.')
+                        if influxVersion == 2:
+                            write_api.write(bucket=bucket, record=usageDataPoints)
                         else:
-                            if influxVersion == 2:
-                                write_api.write(bucket=bucket, record=usageDataPoints)
-                            else:
-                                influx.write_points(usageDataPoints,batch_size=5000)
+                            influx.write_points(usageDataPoints,batch_size=5000)
                         usageDataPoints = []
                         pauseEvent.wait(5)
                     history = False
@@ -537,13 +528,10 @@ try:
                 if not historyrun:
                     info('Submitting datapoints to database; account="{}"; points={}'.format(account['name'], len(usageDataPoints)))
                     dumpPoints("Sending to database", usageDataPoints)
-                    if args.dryrun:
-                        info('Dryrun mode enabled.  Skipping database write.')
+                    if influxVersion == 2:
+                        write_api.write(bucket=bucket, record=usageDataPoints)
                     else:
-                        if influxVersion == 2:
-                            write_api.write(bucket=bucket, record=usageDataPoints)
-                        else:
-                            influx.write_points(usageDataPoints,batch_size=5000)
+                        influx.write_points(usageDataPoints,batch_size=5000)
 
                 # Resuming logging of normal datapoints after history collection has completed.
                 if not history and historyrun:

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -284,7 +284,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                     continue
                 timestamp = usage_start_time + datetime.timedelta(seconds=index)
                 watts = float(secondsInAMinute * minutesInAnHour * wattsInAKw) * kwhUsage
-                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_second))
+                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_second))
                 index += 1
 
         # fetches historical Hour & Day data
@@ -300,7 +300,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                     continue
                 timestamp = usage_start_time + datetime.timedelta(hours=index)
                 watts = kwhUsage * 1000
-                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_hour))
+                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_hour))
                 index += 1
             #Days
             usage, usage_start_time = account['vue'].get_chart_usage(chan, historyStartTime, historyEndTime, scale=Scale.DAY.value, unit=Unit.KWH.value)
@@ -313,7 +313,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                 timestamp = timestamp.replace(hour=23, minute=59, second=59,microsecond=0)
                 timestamp = timestamp.astimezone(pytz.UTC)
                 watts =   kwhUsage * 1000
-                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_day))
+                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_day))
                 index += 1
 
 startupTime = datetime.datetime.now(datetime.UTC).replace(microsecond=0)

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -288,7 +288,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                     continue
                 timestamp = usage_start_time + datetime.timedelta(seconds=index)
                 watts = float(secondsInAMinute * minutesInAnHour * wattsInAKw) * kwhUsage
-                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_second))
+                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_second))
                 index += 1
 
         # fetches historical Hour & Day data
@@ -304,7 +304,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                     continue
                 timestamp = usage_start_time + datetime.timedelta(hours=index)
                 watts = kwhUsage * 1000
-                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_hour))
+                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_hour))
                 index += 1
             #Days
             usage, usage_start_time = account['vue'].get_chart_usage(chan, historyStartTime, historyEndTime, scale=Scale.DAY.value, unit=Unit.KWH.value)
@@ -317,7 +317,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                 timestamp = timestamp.replace(hour=23, minute=59, second=59,microsecond=0)
                 timestamp = timestamp.astimezone(pytz.UTC)
                 watts =   kwhUsage * 1000
-                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_day))
+                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_day))
                 index += 1
 
 startupTime = datetime.datetime.now(datetime.UTC).replace(microsecond=0)

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -18,7 +18,6 @@ import traceback
 from threading import Event
 import argparse
 import pytz
-import pprint
 
 # InfluxDB v1
 import influxdb
@@ -136,10 +135,7 @@ def dumpPoints(label, usageDataPoints):
     if args.debug:
         debug(label)
         for point in usageDataPoints:
-            if influxVersion == 2:
-                debug('  {}'.format(point.to_line_protocol()))
-            else:
-                debug(f'  {pprint.pformat(point)}')
+            debug('  {}'.format(point.to_line_protocol()))
 
 def getLastDBTimeStamp(chanName, pointType, fooStartTime, fooStopTime, fooHistoryFlag):
     timeStr = ''

--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -288,7 +288,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                     continue
                 timestamp = usage_start_time + datetime.timedelta(seconds=index)
                 watts = float(secondsInAMinute * minutesInAnHour * wattsInAKw) * kwhUsage
-                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_second))
+                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_second))
                 index += 1
 
         # fetches historical Hour & Day data
@@ -304,7 +304,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                     continue
                 timestamp = usage_start_time + datetime.timedelta(hours=index)
                 watts = kwhUsage * 1000
-                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_hour))
+                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_hour))
                 index += 1
             #Days
             usage, usage_start_time = account['vue'].get_chart_usage(chan, historyStartTime, historyEndTime, scale=Scale.DAY.value, unit=Unit.KWH.value)
@@ -317,7 +317,7 @@ def extractDataPoints(device, usageDataPoints, pointType=None, historyStartTime=
                 timestamp = timestamp.replace(hour=23, minute=59, second=59,microsecond=0)
                 timestamp = timestamp.astimezone(pytz.UTC)
                 watts =   kwhUsage * 1000
-                usageDataPoints.append(createDataPoint(accountName, deviceName, chanName, watts, timestamp, tagValue_day))
+                usageDataPoints.append(createDataPoint(account, chanName, watts, timestamp, tagValue_day))
                 index += 1
 
 startupTime = datetime.datetime.now(datetime.UTC).replace(microsecond=0)


### PR DESCRIPTION
This adds a tag for the data in device.name called `station_name`, which refers to what the Vue device is named.

Ideally this tag would have been called 'device_name' to follow the naming patterns in the data and code, however `device_name` is already being used for what is called `chanName` in code, i.e. the name of the channel on a particular Vue device.  To not break existing dashboards this tag is given a different, non-conflicting name.

This PR addresses issue #179 