### PR TITLE
Fix deprecated bucket name in alert configuration

### DIFF
--- a/influx_dashboard.json
+++ b/influx_dashboard.json
@@ -20,7 +20,7 @@
 			"every": "1m0s",
 			"level": "CRIT",
 			"name": "Energy Data Lost",
-			"query": "from(bucket: \"vue/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy_usage\")\n  |> filter(fn: (r) => r[\"_field\"] == \"usage\")",
+			"query": "from(bucket: \"vuegraf\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"energy_usage\")\n  |> filter(fn: (r) => r[\"_field\"] == \"usage\")",
 			"staleTime": "10m0s",
 			"status": "active",
 			"statusMessageTemplate": "Check: ${ r._check_name } is: ${ r._level }",


### PR DESCRIPTION
## Description

Replace obsolete 'vue/autogen' bucket name with correct 'vuegraf' bucket name in dashboard alert query.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/vuegraf/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://github.com/jertel/vuegraf/blob/master/README.md).
- [ ] I have updated the [changelog](https://github.com/jertel/vuegraf/blob/master/CHANGELOG.md).
