### PR TITLE
fix(collect): negative-cache minute-backfill when API returns no historical data (closes #209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Other changes
 - Added missing DetailedDataEnabled variable values: Day, Hour - @jertel
+- Fix minute-history backfill loop wedging permanently when a channel's parent has no historical minute data (negative cache with 1h TTL; invisible to channels that have data). - [#209](https://github.com/jertel/vuegraf/issues/209) - @MMeffert
 
 # 1.10.1
 

--- a/src/tests/test_collect.py
+++ b/src/tests/test_collect.py
@@ -3,6 +3,7 @@
 
 import datetime
 import logging
+import time
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -360,6 +361,78 @@ class TestCollect(TestCase):
             unit=Unit.KWH.value
         )
         self.assertEqual(len(self.usage_data_points), 0)  # No data points collected
+
+    def test_extractDataPoints_minute_history_negative_cache_skips_next_cycle(self):
+        # Regression test for the minute-backfill wedge: when get_chart_usage(MINUTE)
+        # persistently returns all-None for a channel, the first cycle exhausts the
+        # backfill window and writes nothing. The negative cache should then
+        # short-circuit subsequent cycles -- no further get_chart_usage calls for
+        # that channel, and the simple current-sample branch writes one minute
+        # point per cycle.
+        self.mock_config['data']['detailedDataMinutesHistoryEnabled'] = True
+        minute_history_start = self.stop_time_utc.replace(second=0, microsecond=0) - datetime.timedelta(hours=12)
+        stop_time_min = self.stop_time_utc.replace(second=0, microsecond=0) - datetime.timedelta(hours=6)
+        self.mock_getLastDBTimeStamp.return_value = (minute_history_start, stop_time_min, True)
+
+        mock_device = self._create_mock_device(12345, [('1,2,3', 0.01, None)])
+
+        # Cycle 1: all-None across the backfill window
+        mock_minute_usage_none = [None] * 10
+        self.mock_account['vue'].get_chart_usage.side_effect = [
+            (mock_minute_usage_none, minute_history_start),
+            (mock_minute_usage_none, stop_time_min),
+            (mock_minute_usage_none, stop_time_min + (stop_time_min - minute_history_start)),
+        ]
+
+        collect.extractDataPoints(self.mock_config, self.mock_account, mock_device, self.stop_time_utc,
+                                  False, self.usage_data_points, self.detailed_start_time_utc)
+
+        # Cycle 1 ran the backfill loop and wrote nothing
+        cycle_1_call_count = self.mock_account['vue'].get_chart_usage.call_count
+        self.assertGreaterEqual(cycle_1_call_count, 2)
+        self.assertEqual(len(self.usage_data_points), 0)
+        # The negative cache should now contain this (device, channel)
+        cache = self.mock_config.get('_minuteBackfillSkipCache', {})
+        self.assertIn(('TestDevice1', 'TestChannel1'), cache)
+
+        # Cycle 2: same mock state, but the cache should short-circuit the backfill.
+        # If the cache fails to engage, get_chart_usage would be called again
+        # (and raise StopIteration since side_effect is exhausted).
+        self.mock_account['vue'].get_chart_usage.side_effect = None  # exhausted; any further call would error
+        self.mock_account['vue'].get_chart_usage.reset_mock()
+
+        collect.extractDataPoints(self.mock_config, self.mock_account, mock_device, self.stop_time_utc,
+                                  False, self.usage_data_points, self.detailed_start_time_utc)
+
+        # Cycle 2 should have made ZERO get_chart_usage calls (cache hit), and
+        # written exactly one minute point via the simple current-sample branch.
+        self.mock_account['vue'].get_chart_usage.assert_not_called()
+        self.assertEqual(len(self.usage_data_points), 1)
+        self.assertEqual(self.usage_data_points[0].chanName, 'TestChannel1')
+
+    def test_extractDataPoints_minute_history_negative_cache_expires(self):
+        # After the cache TTL elapses, the backfill is attempted again -- the
+        # cache is not a permanent skip, just a transient cool-off.
+        self.mock_config['data']['detailedDataMinutesHistoryEnabled'] = True
+        # Pre-seed the cache with an entry that expired one second ago.
+        self.mock_config['_minuteBackfillSkipCache'] = {('TestDevice1', 'TestChannel1'): time.time() - 1}
+
+        minute_history_start = self.stop_time_utc.replace(second=0, microsecond=0) - datetime.timedelta(hours=12)
+        stop_time_min = self.stop_time_utc.replace(second=0, microsecond=0) - datetime.timedelta(hours=6)
+        self.mock_getLastDBTimeStamp.return_value = (minute_history_start, stop_time_min, True)
+
+        mock_device = self._create_mock_device(12345, [('1,2,3', 0.01, None)])
+        # Simulate the API now returning real data -- recovery scenario.
+        mock_minute_usage = [0.005, 0.006, 0.007]
+        self.mock_account['vue'].get_chart_usage.return_value = (mock_minute_usage, minute_history_start)
+
+        collect.extractDataPoints(self.mock_config, self.mock_account, mock_device, self.stop_time_utc,
+                                  False, self.usage_data_points, self.detailed_start_time_utc)
+
+        # Expired cache entry should NOT block the backfill -- get_chart_usage runs,
+        # real points are written.
+        self.mock_account['vue'].get_chart_usage.assert_called_once()
+        self.assertEqual(len(self.usage_data_points), 3)
 
     def test_extractDataPoints_minute_history_skipped_due_to_history_param(self):
         # Test scenario where minute history is enabled, channel not excluded,

--- a/src/vuegraf/collect.py
+++ b/src/vuegraf/collect.py
@@ -6,6 +6,7 @@
 import datetime
 from dataclasses import dataclass
 import logging
+import time
 from typing import Union
 
 from pyemvue.enums import Scale, Unit
@@ -17,6 +18,36 @@ from vuegraf.time import calculateHistoryTimeRange, convertToLocalDayInUTC
 
 
 logger = logging.getLogger('vuegraf.data')
+
+
+# How long to remember that a (device, channel) returned no minute-history data,
+# before attempting the 7-day rewind backfill again. See getMinuteBackfillSkipCache().
+MINUTE_BACKFILL_SKIP_TTL_SEC = 3600  # 1 hour
+
+
+def getMinuteBackfillSkipCache(config):
+    """Negative cache for the minute-history backfill loop in extractDataPoints.
+
+    Some Emporia hardware revisions persistently return all-None from
+    get_chart_usage(scale=MINUTE) for a device's synthesized parent channel
+    (e.g. '1,2,3'), even though hourly/daily aggregates and the live-sample
+    endpoint return real values for the same channel. Without a cache, when
+    InfluxDB has no minute-tagged record for such a channel, getLastDBTimeStamp
+    re-anchors at now - 7 days every cycle, and the backfill while-loop here
+    walks the full 7-day window in 12-hour chunks — fetching nothing and
+    writing nothing — on every single 60s cycle, indefinitely.
+
+    This cache records '(deviceName, chanName) -> expiry_epoch' for channels
+    where a backfill window completed without writing any points. Subsequent
+    cycles short-circuit to the simple current-sample minute point (same path
+    excluded channels already take) until the cache entry expires.
+
+    The cache is bound to the config dict (one cache per Vuegraf process). It
+    stays empty for channels that have data — zero overhead for working
+    installations. Restarting Vuegraf clears it, giving the upstream API a
+    fresh attempt.
+    """
+    return config.setdefault('_minuteBackfillSkipCache', {})
 
 
 @dataclass
@@ -59,16 +90,28 @@ def extractDataPoints(config, account, device, stopTimeUTC, collectDetails, usag
         kwhUsage = chan.usage
         if kwhUsage is not None:
             if pointType is None:
-                # Collect previous minute averages
-                minuteHistoryStartTime, stopTimeMin, minuteHistoryEnabled = getLastDBTimeStamp(config, deviceName,
-                                                                                               chanName, tagValue_minute,
-                                                                                               stopTimeUTC, stopTimeUTC, False)
+                # Negative-cache check: if a prior backfill window for this
+                # (device, channel) completed without writing any minute points,
+                # short-circuit to the simple current-sample branch and skip the
+                # 7-day-rewind getLastDBTimeStamp + while-loop entirely. See
+                # getMinuteBackfillSkipCache for the rationale.
+                skipCache = getMinuteBackfillSkipCache(config)
+                cacheKey = (deviceName, chanName)
+                skipExpiry = skipCache.get(cacheKey)
+                if skipExpiry is not None and skipExpiry > time.time():
+                    minuteHistoryStartTime, stopTimeMin, minuteHistoryEnabled = (stopTimeUTC, stopTimeUTC, False)
+                else:
+                    # Collect previous minute averages
+                    minuteHistoryStartTime, stopTimeMin, minuteHistoryEnabled = getLastDBTimeStamp(config, deviceName,
+                                                                                                   chanName, tagValue_minute,
+                                                                                                   stopTimeUTC, stopTimeUTC, False)
                 if not minuteHistoryEnabled or chanNum in excludedDetailChannelNumbers:
                     watts = float(minutesInAnHour * wattsInAKw) * kwhUsage
                     timestamp = stopTimeUTC.replace(second=0)
                     usageDataPoints.append(Point(accountName, deviceName, chanName, watts, timestamp, tagValue_minute))
                 elif chanNum not in excludedDetailChannelNumbers and historyStartTimeUTC is None:
                     # Still missing recent minute history, attempt to collect in batches of 12 hours
+                    pointsBeforeBackfill = len(usageDataPoints)
                     noDataFlag = True
                     while noDataFlag:
                         # Collect minutes history (if neccessary, never during history collection)
@@ -106,6 +149,17 @@ def extractDataPoints(config, account, device, stopTimeUTC, collectDetails, usag
                             else:  # Time to break out of the loop; looks like the device in question is offline
                                 noDataFlag = False
                         minuteHistoryEnabled = False
+                    if len(usageDataPoints) == pointsBeforeBackfill:
+                        # The backfill window completed without writing any minute
+                        # points -- the upstream API returned all-None across the
+                        # entire 7-day rewind for this (device, channel). Cache the
+                        # negative result so subsequent cycles skip the rewind.
+                        skipCache[cacheKey] = time.time() + MINUTE_BACKFILL_SKIP_TTL_SEC
+                        logger.info(
+                            'No historical minute data for device="%s"; suppressing '
+                            'minute backfill for %ds (cache).',
+                            chanName, MINUTE_BACKFILL_SKIP_TTL_SEC,
+                        )
             elif pointType == tagValue_day:
                 # Collect previous day averages
                 watts = kwhUsage * wattsInAKw


### PR DESCRIPTION
Fixes #209.

When an Emporia channel's parent (e.g. `1,2,3`) persistently returns all-`None` from `get_chart_usage(scale=MINUTE)` — as some hardware revisions do for the synthesized parent rollup, even while sub-channels and hourly/daily aggregates work fine — Vuegraf wedges in a permanent backfill loop. Every 60-second cycle re-anchors at `now - 7 days` (via `getLastDBTimeStamp`'s no-record branch) and walks the full 7-day window in fourteen 12-hour chunks, fetching nothing and writing nothing.

## The fix

A small negative cache, bound to the `config` dict, that records `(deviceName, chanName) -> expiry` when a backfill window completes without appending any minute points. Subsequent cycles short-circuit to the simple current-sample minute branch (the same path excluded channels already take) until the cache entry expires (1 hour TTL).

**Design choices:**
- **Invisible to channels that have data** — their cache slot stays empty. Zero behavior change for working installations.
- **Bound to `config`, not module-level** — gives one cache per Vuegraf process; restart = fresh cache; tests are naturally isolated (each test's `mock_config.copy()` is a fresh outer dict).
- **TTL-bounded (1h)** — so a hardware or upstream API recovery is picked up automatically without a Vuegraf restart.
- **No new config keys** — opt-in-free; works for everyone.

## Tests

Two new tests in `test_collect.py`:

- `test_extractDataPoints_minute_history_negative_cache_skips_next_cycle` — proves a second cycle makes **zero** `get_chart_usage` calls (cache hit) and writes one current-sample minute point via the simple branch.
- `test_extractDataPoints_minute_history_negative_cache_expires` — proves an expired cache entry doesn't block recovery; `get_chart_usage` runs and real data is written.

Full suite: **133 passed** (was 131 — +2 new tests, 0 regressions).

## Files touched

- `src/vuegraf/collect.py` — added `MINUTE_BACKFILL_SKIP_TTL_SEC`, `getMinuteBackfillSkipCache(config)` helper, and ~12 lines in `extractDataPoints` (cache check before `getLastDBTimeStamp`; cache populate after the `while noDataFlag` loop if zero points were appended).
- `src/tests/test_collect.py` — two new tests.
- `CHANGELOG.md` — entry under the `1.TBD.TBD` "Other changes" section per CONTRIBUTING.

No README change because no new config option is introduced.
